### PR TITLE
iOS implementation - fire the battery status update event upon registering

### DIFF
--- a/src/ios/CDVBattery.m
+++ b/src/ios/CDVBattery.m
@@ -111,6 +111,8 @@
                                                      name:UIDeviceBatteryStateDidChangeNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateBatteryStatus:)
                                                      name:UIDeviceBatteryLevelDidChangeNotification object:nil];
+
+        [self updateBatteryStatus: nil];
     }
 }
 


### PR DESCRIPTION
The goal is to match the Android implementation.